### PR TITLE
fix support for macOS and Linux & add EAP-MD5 CHAP method

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Then you get `sysuh3c` executable file in `/usr/local/bin`.
 -u --user        user account (must!)
 -p --password    password
 -i --iface       network interface (default is eth0)
+-m --method      EAP-MD5 CHAP method (default 0)
+                     0 = xor
+                     1 = md5
 -d --daemonize   daemonize
 -c --colorize    colorize
 ```

--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ Then you get `sysuh3c` executable file in `/usr/local/bin`.
 -u --user        user account (must!)
 -p --password    password
 -i --iface       network interface (default is eth0)
--m --method      EAP-MD5 CHAP method (default 0)
-                     0 = xor
-                     1 = md5
+-m --method      EAP-MD5 CHAP method [xor/md5] (default xor)
 -d --daemonize   daemonize
 -c --colorize    colorize
 ```

--- a/src/eapauth/SConscript
+++ b/src/eapauth/SConscript
@@ -11,6 +11,7 @@ env.StaticLibrary('eapauth',
     [
         'eapauth.cpp', 
         'eapdef.cpp', 
-        'eaputils.cpp'
+        'eaputils.cpp',
+        'md5.cpp'
     ]
 )

--- a/src/eapauth/eapauth.h
+++ b/src/eapauth/eapauth.h
@@ -12,7 +12,7 @@ namespace sysuh3c {
 
 class EAPAuth {
 public:
-    EAPAuth(const std::string &, const std::string &, const std::string &, const std::string &);
+    EAPAuth(const std::string &, const std::string &, const std::string &, eap_method);
     ~EAPAuth();
 
     void auth();
@@ -36,7 +36,7 @@ private:
     EAPClient eapclient;
     std::string user_name;
     std::string user_password;
-    std::string md5_method;
+    eap_method md5_method;
 
     std::function<void(const std::string &)> display_promote;
     std::function<void(int statno)> status_notify;

--- a/src/eapauth/eapauth.h
+++ b/src/eapauth/eapauth.h
@@ -12,7 +12,7 @@ namespace sysuh3c {
 
 class EAPAuth {
 public:
-    EAPAuth(const std::string &, const std::string &, const std::string &);
+    EAPAuth(const std::string &, const std::string &, const std::string &, const std::string &);
     ~EAPAuth();
 
     void auth();
@@ -36,6 +36,7 @@ private:
     EAPClient eapclient;
     std::string user_name;
     std::string user_password;
+    std::string md5_method;
 
     std::function<void(const std::string &)> display_promote;
     std::function<void(int statno)> status_notify;

--- a/src/eapauth/eapdef.h
+++ b/src/eapauth/eapdef.h
@@ -78,7 +78,7 @@ struct eapol_t {
 
 struct ethernet_header_t {
     mac_addr_t dest;
-    mac_addr_t src[6];
+    mac_addr_t src;
     uint16_t type;
 } __attribute__((packed));
 

--- a/src/eapauth/eapdef.h
+++ b/src/eapauth/eapdef.h
@@ -96,6 +96,11 @@ enum {
     EAPAUTH_AUTH_MD5
 };
 
+enum eap_method {
+    EAP_METHOD_XOR,
+    EAP_METHOD_MD5
+};
+
 inline std::string strstat(int statno) {
     switch (statno) {
     case EAPAUTH_UNKNOWN_REQUEST_TYPE:

--- a/src/eapauth/eaputils.h
+++ b/src/eapauth/eaputils.h
@@ -59,6 +59,7 @@ private:
     struct sockaddr_ll sock_addr;
     #elif SYSTEM_DARWIN
     struct sockaddr_dl sock_addr;
+    mac_addr_t mac_addr;
     int bpf_fd;
     struct timeval timeout;
     #endif

--- a/src/eapauth/md5.cpp
+++ b/src/eapauth/md5.cpp
@@ -1,0 +1,291 @@
+/*
+ * This is an OpenSSL-compatible implementation of the RSA Data Security, Inc.
+ * MD5 Message-Digest Algorithm (RFC 1321).
+ *
+ * Homepage:
+ * http://openwall.info/wiki/people/solar/software/public-domain-source-code/md5
+ *
+ * Author:
+ * Alexander Peslyak, better known as Solar Designer <solar at openwall.com>
+ *
+ * This software was written by Alexander Peslyak in 2001.  No copyright is
+ * claimed, and the software is hereby placed in the public domain.
+ * In case this attempt to disclaim copyright and place the software in the
+ * public domain is deemed null and void, then the software is
+ * Copyright (c) 2001 Alexander Peslyak and it is hereby released to the
+ * general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ * There's ABSOLUTELY NO WARRANTY, express or implied.
+ *
+ * (This is a heavily cut-down "BSD license".)
+ *
+ * This differs from Colin Plumb's older public domain implementation in that
+ * no exactly 32-bit integer data type is required (any 32-bit or wider
+ * unsigned integer data type will do), there's no compile-time endianness
+ * configuration, and the function prototypes match OpenSSL's.  No code from
+ * Colin Plumb's implementation has been reused; this comment merely compares
+ * the properties of the two independent implementations.
+ *
+ * The primary goals of this implementation are portability and ease of use.
+ * It is meant to be fast, but not as fast as possible.  Some known
+ * optimizations are not included to reduce source code size and avoid
+ * compile-time configuration.
+ */
+
+#ifndef HAVE_OPENSSL
+
+#include <string.h>
+
+#include "md5.h"
+
+/*
+ * The basic MD5 functions.
+ *
+ * F and G are optimized compared to their RFC 1321 definitions for
+ * architectures that lack an AND-NOT instruction, just like in Colin Plumb's
+ * implementation.
+ */
+#define F(x, y, z)			((z) ^ ((x) & ((y) ^ (z))))
+#define G(x, y, z)			((y) ^ ((z) & ((x) ^ (y))))
+#define H(x, y, z)			(((x) ^ (y)) ^ (z))
+#define H2(x, y, z)			((x) ^ ((y) ^ (z)))
+#define I(x, y, z)			((y) ^ ((x) | ~(z)))
+
+/*
+ * The MD5 transformation for all four rounds.
+ */
+#define STEP(f, a, b, c, d, x, t, s) \
+	(a) += f((b), (c), (d)) + (x) + (t); \
+	(a) = (((a) << (s)) | (((a) & 0xffffffff) >> (32 - (s)))); \
+	(a) += (b);
+
+/*
+ * SET reads 4 input bytes in little-endian byte order and stores them in a
+ * properly aligned word in host byte order.
+ *
+ * The check for little-endian architectures that tolerate unaligned memory
+ * accesses is just an optimization.  Nothing will break if it fails to detect
+ * a suitable architecture.
+ *
+ * Unfortunately, this optimization may be a C strict aliasing rules violation
+ * if the caller's data buffer has effective type that cannot be aliased by
+ * MD5_u32plus.  In practice, this problem may occur if these MD5 routines are
+ * inlined into a calling function, or with future and dangerously advanced
+ * link-time optimizations.  For the time being, keeping these MD5 routines in
+ * their own translation unit avoids the problem.
+ */
+#if defined(__i386__) || defined(__x86_64__) || defined(__vax__)
+#define SET(n) \
+	(*(MD5_u32plus *)&ptr[(n) * 4])
+#define GET(n) \
+	SET(n)
+#else
+#define SET(n) \
+	(ctx->block[(n)] = \
+	(MD5_u32plus)ptr[(n) * 4] | \
+	((MD5_u32plus)ptr[(n) * 4 + 1] << 8) | \
+	((MD5_u32plus)ptr[(n) * 4 + 2] << 16) | \
+	((MD5_u32plus)ptr[(n) * 4 + 3] << 24))
+#define GET(n) \
+	(ctx->block[(n)])
+#endif
+
+/*
+ * This processes one or more 64-byte data blocks, but does NOT update the bit
+ * counters.  There are no alignment requirements.
+ */
+static const void *body(MD5_CTX *ctx, const void *data, unsigned long size)
+{
+	const unsigned char *ptr;
+	MD5_u32plus a, b, c, d;
+	MD5_u32plus saved_a, saved_b, saved_c, saved_d;
+
+	ptr = (const unsigned char *)data;
+
+	a = ctx->a;
+	b = ctx->b;
+	c = ctx->c;
+	d = ctx->d;
+
+	do {
+		saved_a = a;
+		saved_b = b;
+		saved_c = c;
+		saved_d = d;
+
+/* Round 1 */
+		STEP(F, a, b, c, d, SET(0), 0xd76aa478, 7)
+		STEP(F, d, a, b, c, SET(1), 0xe8c7b756, 12)
+		STEP(F, c, d, a, b, SET(2), 0x242070db, 17)
+		STEP(F, b, c, d, a, SET(3), 0xc1bdceee, 22)
+		STEP(F, a, b, c, d, SET(4), 0xf57c0faf, 7)
+		STEP(F, d, a, b, c, SET(5), 0x4787c62a, 12)
+		STEP(F, c, d, a, b, SET(6), 0xa8304613, 17)
+		STEP(F, b, c, d, a, SET(7), 0xfd469501, 22)
+		STEP(F, a, b, c, d, SET(8), 0x698098d8, 7)
+		STEP(F, d, a, b, c, SET(9), 0x8b44f7af, 12)
+		STEP(F, c, d, a, b, SET(10), 0xffff5bb1, 17)
+		STEP(F, b, c, d, a, SET(11), 0x895cd7be, 22)
+		STEP(F, a, b, c, d, SET(12), 0x6b901122, 7)
+		STEP(F, d, a, b, c, SET(13), 0xfd987193, 12)
+		STEP(F, c, d, a, b, SET(14), 0xa679438e, 17)
+		STEP(F, b, c, d, a, SET(15), 0x49b40821, 22)
+
+/* Round 2 */
+		STEP(G, a, b, c, d, GET(1), 0xf61e2562, 5)
+		STEP(G, d, a, b, c, GET(6), 0xc040b340, 9)
+		STEP(G, c, d, a, b, GET(11), 0x265e5a51, 14)
+		STEP(G, b, c, d, a, GET(0), 0xe9b6c7aa, 20)
+		STEP(G, a, b, c, d, GET(5), 0xd62f105d, 5)
+		STEP(G, d, a, b, c, GET(10), 0x02441453, 9)
+		STEP(G, c, d, a, b, GET(15), 0xd8a1e681, 14)
+		STEP(G, b, c, d, a, GET(4), 0xe7d3fbc8, 20)
+		STEP(G, a, b, c, d, GET(9), 0x21e1cde6, 5)
+		STEP(G, d, a, b, c, GET(14), 0xc33707d6, 9)
+		STEP(G, c, d, a, b, GET(3), 0xf4d50d87, 14)
+		STEP(G, b, c, d, a, GET(8), 0x455a14ed, 20)
+		STEP(G, a, b, c, d, GET(13), 0xa9e3e905, 5)
+		STEP(G, d, a, b, c, GET(2), 0xfcefa3f8, 9)
+		STEP(G, c, d, a, b, GET(7), 0x676f02d9, 14)
+		STEP(G, b, c, d, a, GET(12), 0x8d2a4c8a, 20)
+
+/* Round 3 */
+		STEP(H, a, b, c, d, GET(5), 0xfffa3942, 4)
+		STEP(H2, d, a, b, c, GET(8), 0x8771f681, 11)
+		STEP(H, c, d, a, b, GET(11), 0x6d9d6122, 16)
+		STEP(H2, b, c, d, a, GET(14), 0xfde5380c, 23)
+		STEP(H, a, b, c, d, GET(1), 0xa4beea44, 4)
+		STEP(H2, d, a, b, c, GET(4), 0x4bdecfa9, 11)
+		STEP(H, c, d, a, b, GET(7), 0xf6bb4b60, 16)
+		STEP(H2, b, c, d, a, GET(10), 0xbebfbc70, 23)
+		STEP(H, a, b, c, d, GET(13), 0x289b7ec6, 4)
+		STEP(H2, d, a, b, c, GET(0), 0xeaa127fa, 11)
+		STEP(H, c, d, a, b, GET(3), 0xd4ef3085, 16)
+		STEP(H2, b, c, d, a, GET(6), 0x04881d05, 23)
+		STEP(H, a, b, c, d, GET(9), 0xd9d4d039, 4)
+		STEP(H2, d, a, b, c, GET(12), 0xe6db99e5, 11)
+		STEP(H, c, d, a, b, GET(15), 0x1fa27cf8, 16)
+		STEP(H2, b, c, d, a, GET(2), 0xc4ac5665, 23)
+
+/* Round 4 */
+		STEP(I, a, b, c, d, GET(0), 0xf4292244, 6)
+		STEP(I, d, a, b, c, GET(7), 0x432aff97, 10)
+		STEP(I, c, d, a, b, GET(14), 0xab9423a7, 15)
+		STEP(I, b, c, d, a, GET(5), 0xfc93a039, 21)
+		STEP(I, a, b, c, d, GET(12), 0x655b59c3, 6)
+		STEP(I, d, a, b, c, GET(3), 0x8f0ccc92, 10)
+		STEP(I, c, d, a, b, GET(10), 0xffeff47d, 15)
+		STEP(I, b, c, d, a, GET(1), 0x85845dd1, 21)
+		STEP(I, a, b, c, d, GET(8), 0x6fa87e4f, 6)
+		STEP(I, d, a, b, c, GET(15), 0xfe2ce6e0, 10)
+		STEP(I, c, d, a, b, GET(6), 0xa3014314, 15)
+		STEP(I, b, c, d, a, GET(13), 0x4e0811a1, 21)
+		STEP(I, a, b, c, d, GET(4), 0xf7537e82, 6)
+		STEP(I, d, a, b, c, GET(11), 0xbd3af235, 10)
+		STEP(I, c, d, a, b, GET(2), 0x2ad7d2bb, 15)
+		STEP(I, b, c, d, a, GET(9), 0xeb86d391, 21)
+
+		a += saved_a;
+		b += saved_b;
+		c += saved_c;
+		d += saved_d;
+
+		ptr += 64;
+	} while (size -= 64);
+
+	ctx->a = a;
+	ctx->b = b;
+	ctx->c = c;
+	ctx->d = d;
+
+	return ptr;
+}
+
+void MD5_Init(MD5_CTX *ctx)
+{
+	ctx->a = 0x67452301;
+	ctx->b = 0xefcdab89;
+	ctx->c = 0x98badcfe;
+	ctx->d = 0x10325476;
+
+	ctx->lo = 0;
+	ctx->hi = 0;
+}
+
+void MD5_Update(MD5_CTX *ctx, const void *data, unsigned long size)
+{
+	MD5_u32plus saved_lo;
+	unsigned long used, available;
+
+	saved_lo = ctx->lo;
+	if ((ctx->lo = (saved_lo + size) & 0x1fffffff) < saved_lo)
+		ctx->hi++;
+	ctx->hi += size >> 29;
+
+	used = saved_lo & 0x3f;
+
+	if (used) {
+		available = 64 - used;
+
+		if (size < available) {
+			memcpy(&ctx->buffer[used], data, size);
+			return;
+		}
+
+		memcpy(&ctx->buffer[used], data, available);
+		data = (const unsigned char *)data + available;
+		size -= available;
+		body(ctx, ctx->buffer, 64);
+	}
+
+	if (size >= 64) {
+		data = body(ctx, data, size & ~(unsigned long)0x3f);
+		size &= 0x3f;
+	}
+
+	memcpy(ctx->buffer, data, size);
+}
+
+#define OUT(dst, src) \
+	(dst)[0] = (unsigned char)(src); \
+	(dst)[1] = (unsigned char)((src) >> 8); \
+	(dst)[2] = (unsigned char)((src) >> 16); \
+	(dst)[3] = (unsigned char)((src) >> 24);
+
+void MD5_Final(unsigned char *result, MD5_CTX *ctx)
+{
+	unsigned long used, available;
+
+	used = ctx->lo & 0x3f;
+
+	ctx->buffer[used++] = 0x80;
+
+	available = 64 - used;
+
+	if (available < 8) {
+		memset(&ctx->buffer[used], 0, available);
+		body(ctx, ctx->buffer, 64);
+		used = 0;
+		available = 64;
+	}
+
+	memset(&ctx->buffer[used], 0, available - 8);
+
+	ctx->lo <<= 3;
+	OUT(&ctx->buffer[56], ctx->lo)
+	OUT(&ctx->buffer[60], ctx->hi)
+
+	body(ctx, ctx->buffer, 64);
+
+	OUT(&result[0], ctx->a)
+	OUT(&result[4], ctx->b)
+	OUT(&result[8], ctx->c)
+	OUT(&result[12], ctx->d)
+
+	memset(ctx, 0, sizeof(*ctx));
+}
+
+#endif

--- a/src/eapauth/md5.h
+++ b/src/eapauth/md5.h
@@ -1,0 +1,45 @@
+/*
+ * This is an OpenSSL-compatible implementation of the RSA Data Security, Inc.
+ * MD5 Message-Digest Algorithm (RFC 1321).
+ *
+ * Homepage:
+ * http://openwall.info/wiki/people/solar/software/public-domain-source-code/md5
+ *
+ * Author:
+ * Alexander Peslyak, better known as Solar Designer <solar at openwall.com>
+ *
+ * This software was written by Alexander Peslyak in 2001.  No copyright is
+ * claimed, and the software is hereby placed in the public domain.
+ * In case this attempt to disclaim copyright and place the software in the
+ * public domain is deemed null and void, then the software is
+ * Copyright (c) 2001 Alexander Peslyak and it is hereby released to the
+ * general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ * There's ABSOLUTELY NO WARRANTY, express or implied.
+ *
+ * See md5.c for more information.
+ */
+
+#ifdef HAVE_OPENSSL
+#include <openssl/md5.h>
+#elif !defined(_MD5_H)
+#define _MD5_H
+
+/* Any 32-bit or wider unsigned integer data type will do */
+typedef unsigned int MD5_u32plus;
+
+typedef struct {
+	MD5_u32plus lo, hi;
+	MD5_u32plus a, b, c, d;
+	unsigned char buffer[64];
+	MD5_u32plus block[16];
+} MD5_CTX;
+
+extern void MD5_Init(MD5_CTX *ctx);
+extern void MD5_Update(MD5_CTX *ctx, const void *data, unsigned long size);
+extern void MD5_Final(unsigned char *result, MD5_CTX *ctx);
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,7 +87,8 @@ int main(int argc, char *const argv[]) {
         {NULL, 0, NULL, 0}
     };
 
-    string name, password, iface("eth0"), method("0");
+    string name, password, iface("eth0");
+    eap_method method = EAP_METHOD_XOR;
     bool daemon = false;
     bool color = false;
     char argval;
@@ -99,9 +100,7 @@ int main(int argc, char *const argv[]) {
                    "   -u --user       user account\n"
                    "   -p --password   password\n"
                    "   -i --iface      network interface (default eth0)\n"
-                   "   -m --method     EAP-MD5 CHAP method (default 0)\n"
-                   "                       0 = xor\n"
-                   "                       1 = md5\n"
+                   "   -m --method     EAP-MD5 CHAP method [xor/md5] (default xor)\n"
                    "   -d --daemonize  daemonize\n"
                    "   -c --colorize   colorize\n");
             exit(EXIT_SUCCESS);
@@ -115,7 +114,14 @@ int main(int argc, char *const argv[]) {
             iface = optarg;
             break;
         case 'm':
-            method = optarg;
+            if (string(optarg) == "xor")
+                method = EAP_METHOD_XOR;
+            else if (string(optarg) == "md5")
+                method = EAP_METHOD_MD5;
+            else {
+                cerr <<  "Argument Error! Method can only be xor or md5." << endl;
+                return EXIT_FAILURE;
+            }
             break;
         case 'd':
             daemon = true;
@@ -136,10 +142,6 @@ int main(int argc, char *const argv[]) {
     if (password.empty()) {
         char *pwd = getpass("Password: ");
         password = pwd;
-    }
-    if (method != "0" && method != "1") {
-        cerr <<  "Argument Error! Method can only be 0 or 1." << endl;
-        return EXIT_FAILURE;
     }
 
     EAPAuth authservice(name, password, iface, method);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,16 +81,17 @@ int main(int argc, char *const argv[]) {
         {"user", required_argument, NULL, 'u'},
         {"password", required_argument, NULL, 'p'},
         {"iface", optional_argument, NULL, 'i'},
+        {"method", optional_argument, NULL, 'm'},
         {"daemonize", no_argument, NULL, 'd'},
         {"colorize", no_argument, NULL, 'c'},
         {NULL, 0, NULL, 0}
     };
 
-    string name, password, iface("eth0");
+    string name, password, iface("eth0"), method("0");
     bool daemon = false;
     bool color = false;
     char argval;
-    while ((argval = getopt_long(argc, argv, "u:p:i:dhc", arglist, NULL)) != -1) {
+    while ((argval = getopt_long(argc, argv, "u:p:i:m:dhc", arglist, NULL)) != -1) {
         switch (argval) {
         case 'h':
             printf("Usage: sysuh3c [arg]\n"
@@ -98,6 +99,9 @@ int main(int argc, char *const argv[]) {
                    "   -u --user       user account\n"
                    "   -p --password   password\n"
                    "   -i --iface      network interface (default eth0)\n"
+                   "   -m --method     EAP-MD5 CHAP method (default 0)\n"
+                   "                       0 = xor\n"
+                   "                       1 = md5\n"
                    "   -d --daemonize  daemonize\n"
                    "   -c --colorize   colorize\n");
             exit(EXIT_SUCCESS);
@@ -109,6 +113,9 @@ int main(int argc, char *const argv[]) {
             break;
         case 'i':
             iface = optarg;
+            break;
+        case 'm':
+            method = optarg;
             break;
         case 'd':
             daemon = true;
@@ -130,8 +137,12 @@ int main(int argc, char *const argv[]) {
         char *pwd = getpass("Password: ");
         password = pwd;
     }
+    if (method != "0" && method != "1") {
+        cerr <<  "Argument Error! Method can only be 0 or 1." << endl;
+        return EXIT_FAILURE;
+    }
 
-    EAPAuth authservice(name, password, iface);
+    EAPAuth authservice(name, password, iface, method);
 
     authservice.set_promote_listener([] (const string & msg) {
         string cpmsg(std::move(msg));


### PR DESCRIPTION
- Tested on macOS 10.12.1 and Ubuntu 16.04.
- Fix #9 
- Now able to choose between old and new CHAP method. See [README.md](https://github.com/benwwchen/sysuh3c/blob/cpp0x/README.md).