### PR TITLE
eapauth.c:bugfix: fix SIGTRAP Error

### DIFF
--- a/src/eapauth.c
+++ b/src/eapauth.c
@@ -198,7 +198,7 @@ int client_recv(const eapauth_t *user, eapol_t *data) {
         data->eap.eap_len = ntohs(*((uint16_t *)(&ptr[6])));
         if (data->eap.eap_len > 4) {
             data->eap.reqtype = ptr[8];
-            memcpy(data->eap.data, ptr + 10, data->eap.eap_len - 6);
+            memcpy(data->eap.data, ptr + 10, data->eap.eap_len);
         }
     }
 


### PR DESCRIPTION
This program can not work properly on the latest OpenWrt trunk. When trying to make authentication, it throws SIGTRAP Exception like this:
```
EAP Auth Start
Trace/breakpoint trap
```
This issue is caused by the using of negative parameter when calling the function memcpy.
This commit fixes this issue and has been tested on the latest OpenWrt trunk.